### PR TITLE
[horizon][pd-1903] template autocomplete flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,6 +260,11 @@
 #    (optional) The session timeout for horizon in seconds. After this manys seconds of inavtivity
 #    the user is logged out.
 #    Defaults to 1800.
+#  
+#  [*password_autocomplete*]
+#    (optional) When the flag is set to off the users browser is instructed to no autofill the login
+#    form with cached credentials.
+#    Defaults to off
 #
 # === Examples
 #
@@ -322,6 +327,7 @@ class horizon(
   $image_backend                       = {},
   $overview_days_range                 = undef,
   $session_timeout                     = 1800,
+  $password_autocomplete               = 'off',
   # DEPRECATED PARAMETERS
   $can_set_mount_point                 = undef,
   $vhost_extra_params                  = undef,

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -104,6 +104,7 @@ HORIZON_CONFIG = {
 
 # Turn off browser autocompletion for the login form if so desired.
 # HORIZON_CONFIG["password_autocomplete"] = "off"
+HORIZON_CONFIG["password_autocomplete"] = "<%= @password_autocomplete %>"
 
 LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
When the flag is set to off the users browser is instructed to not
autofill the login form with cached credentials.
Defaults to off
